### PR TITLE
specify width and height on AddPage() to maintain size of merged PDFs

### DIFF
--- a/src/Merger.php
+++ b/src/Merger.php
@@ -58,7 +58,7 @@ class Merger{
                     $template = $tcpdi->importPage($page);
                     $size = $tcpdi->getTemplateSize($template);
                     $orientation = ($size['w'] > $size['h']) ? 'L' : 'P';
-                    $tcpdi->AddPage($orientation);                    
+                    $tcpdi->AddPage($orientation, array($size['w'], $size['h']));                    
                     $tcpdi->useTemplate($template);
                 }
             }


### PR DESCRIPTION
My merged PDFs were saving as 8.27 x 11.69 in. instead of 8.5 x 11 in. of the original files — this fixes that issue (the change is pulled directly from libmergepdf).